### PR TITLE
Use tags for role dependencies.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,8 +3,10 @@
 dependencies:
 
   - role: debops.secret
+    tags: [ 'depend::secret', 'depend::secret:mariadb_server', 'depend-of::mariadb_server', 'type::dependency:hard' ]
 
   - role: debops.ferm
+    tags: [ 'depend::ferm', 'depend::ferm:mariadb_server', 'depend-of::mariadb_server', 'type::dependency' ]
     ferm_input_list:
 
       - type: 'dport_accept'
@@ -14,6 +16,7 @@ dependencies:
         filename: 'mariadb_dependency_accept'
 
   - role: debops.tcpwrappers
+    tags: [ 'depend::tcpwrappers', 'depend::tcpwrappers:mariadb_server', 'depend-of::mariadb_server', 'type::dependency' ]
     tcpwrappers_allow:
 
       - daemon: 'mysqld'


### PR DESCRIPTION
Maybe not needed after the [RFC: Drop role dependencies from roles](https://github.com/debops/debops-playbooks/issues/192) but I needed it now so :)