### PR TITLE
Add an option to disable CREATE DATABASE in backup

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -320,6 +320,12 @@ mariadb_server__backup: True
 mariadb_server__backup_mailaddr: 'backup'
 
 
+# .. envvar:: mariadb_server__backup_create_database
+#
+# If the backup should contain a CREATE DATABASE statement or not.
+mariadb_server__backup_create_database: True
+
+
 # .. envvar:: mariadb_server__backup_doweekly
 #
 # Specify the day of the week to create weekly backups

--- a/templates/etc/default/automysqlbackup.j2
+++ b/templates/etc/default/automysqlbackup.j2
@@ -58,7 +58,7 @@ MDBNAMES="mysql $DBNAMES"
 DBEXCLUDE=""
 
 # Include CREATE DATABASE in backup?
-CREATE_DATABASE=yes
+CREATE_DATABASE={{ 'yes' if mariadb_server__backup_create_database|bool else 'no' }}
 
 # Separate backup directory and file for each DB? (yes or no)
 SEPDIR=yes


### PR DESCRIPTION
Useful when you want to use backups for staging and dev environments.