### PR TITLE
new param: mariadb_server__local_infile

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -167,7 +167,7 @@ mariadb_server__mysqld_performance_options:
 # .. envvar:: mariadb_server__local_infile
 #
 # Enable or disable LOCAL capability for LOAD DATA INFILE.
-mariadb_server__local_infile: '0'
+mariadb_server__local_infile: False
 
 
 # .. envvar:: mariadb_server__mysqld_security_options

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -174,7 +174,7 @@ mariadb_server__local_infile: '0'
 #
 # Configuration options related to the server security.
 mariadb_server__mysqld_security_options:
-  'local_infile':         '{{ mariadb_server__local_infile }}'
+  'local_infile':         '{{ "1" if mariadb_server__local_infile|bool else "0" }}'
 
 
 # .. envvar:: mariadb_server__mysqld_charset_options

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -164,11 +164,17 @@ mariadb_server__mysqld_performance_options:
   'query_cache_type':             '0'
 
 
+# .. envvar:: mariadb_server__local_infile
+#
+# Enable or disable LOCAL capability for LOAD DATA INFILE.
+mariadb_server__local_infile: '0'
+
+
 # .. envvar:: mariadb_server__mysqld_security_options
 #
 # Configuration options related to the server security.
 mariadb_server__mysqld_security_options:
-  'local_infile':         '0'
+  'local_infile':         '{{ mariadb_server__local_infile }}'
 
 
 # .. envvar:: mariadb_server__mysqld_charset_options


### PR DESCRIPTION
It would be better than this setting were a separate parameter.

Thus we could better control per host without overwriting the entire `mariadb_server__mysqld_security_options` parameter.