### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ Changed
 
 - Fix typo in variable name ``mariadb_server_backup``. [ganto]
 
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 
 `debops.mariadb_server v0.2.4`_ - 2016-08-01
 --------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,7 @@ Changed
 
 - Fix typo in variable name ``mariadb_server_backup``. [ganto]
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 
 `debops.mariadb_server v0.2.4`_ - 2016-08-01

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,8 @@ Changed
 
 - Fix typo in variable name ``mariadb_server_backup``. [ganto]
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 
 `debops.mariadb_server v0.2.4`_ - 2016-08-01

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   description: 'Install and manage a MariaDB / MySQL server'
   company: 'DebOps'
   license: 'GPL-3.0'
-  min_ansible_version: '1.8.0'
+  min_ansible_version: '2.2.0'
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
     LC_MESSAGES: 'C'
   shell: dpkg-query -W -f='${Version}\n' 'mariadb-server' 'mysql-server' 'percona-server-server' 'mysql-wsrep-server-5.6' | grep -v '^$'
   register: mariadb_server__register_version
-  check_mode: no
+  check_mode: False
   changed_when: False
   failed_when: False
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
     LC_MESSAGES: 'C'
   shell: dpkg-query -W -f='${Version}\n' 'mariadb-server' 'mysql-server' 'percona-server-server' 'mysql-wsrep-server-5.6' | grep -v '^$'
   register: mariadb_server__register_version
-  always_run: True
+  check_mode: no
   changed_when: False
   failed_when: False
 


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.