### PR TITLE
Adjust to Galera repository changes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,9 @@
 # - ``mysql-5.6_galera-3``: use MySQL 5.6 engine with Galera from Codership
 #   repository
 #
+# - ``mysql-5.7_galera-3``: use MySQL 5.7 engine with Galera from Codership
+#   repository
+#
 # - ``percona``: use Percona XtraDB engine from upstream repository
 #
 # The choice depends on availability of MariaDB packages in a distribution.
@@ -61,6 +64,7 @@ mariadb_server__apt_key: '{{ mariadb_server__apt_key_map[mariadb_server__flavor]
 mariadb_server__apt_key_map:
   'mariadb_upstream':   [ '199369E5404BD5FC7D2FE43BCBCB082A1BB943DB', '177F4010FE56CA3336300305F1656F24C74CD1D8' ]
   'mysql-5.6_galera-3': '44B7345738EBDE52594DAD80D669017EBC19DDBA'
+  'mysql-5.7_galera-3': '44B7345738EBDE52594DAD80D669017EBC19DDBA'
   'percona':            '4D1BB29D63D98E422B2113B19334A25F8507EFA5'
 
                                                                    # ]]]
@@ -83,7 +87,12 @@ mariadb_server__upstream_mirror: 'http://nyc2.mirrors.digitalocean.com/mariadb/r
 # if any of the listed flavors is selected.
 mariadb_server__apt_repository_map:
   'mariadb_upstream':   'deb {{ mariadb_server__upstream_mirror }} {{ ansible_distribution_release }} main'
-  'mysql-5.6_galera-3': 'deb http://releases.galeracluster.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main'
+  'mysql-5.6_galera-3':
+    - 'deb http://releases.galeracluster.com/mysql-wsrep-5.6/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main'
+    - 'deb http://releases.galeracluster.com/galera-3/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main'
+  'mysql-5.7_galera-3':
+    - 'deb http://releases.galeracluster.com/mysql-wsrep-5.7/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main'
+    - 'deb http://releases.galeracluster.com/galera-3/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main'
   'percona':            'deb http://repo.percona.com/apt {{ ansible_distribution_release }} main'
 
                                                                    # ]]]
@@ -109,6 +118,7 @@ mariadb_server__packages_map:
   'mariadb_upstream': [ 'mariadb-server' ]
   'mysql': [ 'mysql-server' ]
   'mysql-5.6_galera-3': [ 'mysql-wsrep-server-5.6', 'galera-3', 'galera-arbitrator-3' ]
+  'mysql-5.7_galera-3': [ 'mysql-wsrep-server-5.7', 'galera-3', 'galera-arbitrator-3' ]
   'percona': [ 'percona-server-server' ]
                                                                    # ]]]
                                                                    # ]]]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,11 +28,14 @@
 
 - name: Add custom APT repository
   apt_repository:
-    repo: '{{ mariadb_server__apt_repository_map[mariadb_server__flavor] }}'
+    repo: '{{ item }}'
     state: 'present'
     update_cache: True
     mode: '0644'
   when: mariadb_server__flavor in mariadb_server__apt_repository_map.keys()
+  with_flattened: '{{ ([ mariadb_server__apt_repository_map[mariadb_server__flavor] ]
+                       if mariadb_server__apt_repository_map[mariadb_server__flavor] is string
+                       else mariadb_server__apt_repository_map[mariadb_server__flavor]) }}'
 
 - name: Install database server packages
   apt:


### PR DESCRIPTION
The latest version of the Galera MySQL flavor is available via new repository layout as announced in [Announcing Galera Cluster 5.7.18, 5.6.36 and 5.5.55 with Galera 3.21. Improvements to IPv6 Support, Bug Fixes and Changes to Repositories Structure](http://galeracluster.com/2017/07/announcing-galera-cluster-5-7-18-5-6-36-and-5-5-55-with-galera-3-21-improvements-to-ipv6-support-bug-fixes-and-changes-to-repositories-structure/).

This PR adjusts `mariadb_server__apt_repository_map` and the corresponding task according to the new requirements and further adds a new flavor for the MySQL 5.7 series of Galera packages.

Role users using the `mysql-5.6_galera-3` flavor will only get the latest packages after updating the role with the proposed patches or manually adjusting the repository configuration.