### PR TITLE
allow user to specify datadir

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -157,6 +157,12 @@ mariadb_server__allow: []
 mariadb_server__max_connections: '100'
 
                                                                    # ]]]
+# .. envvar:: mariadb_server__datadir [[[
+#
+# Directory to store data
+mariadb_server__datadir: '/var/lib/mysql'
+
+                                                                   # ]]]
 # .. envvar:: mariadb_server__delegate_to [[[
 #
 # Hostname of the server to which Ansible roles will delegate tasks. It should
@@ -242,6 +248,13 @@ mariadb_server__mysqld_cluster_options:
     'innodb_autoinc_lock_mode': '2'
 
                                                                    # ]]]
+# .. envvar:: mariadb_server__mysqld_directory_options [[[
+#
+# Configuration options related to directory (e.g. datadir)
+mariadb_server__mysqld_directory_options:
+  'datadir': '{{ mariadb_server__datadir }}'
+
+                                                                   # ]]]
 # .. envvar:: mariadb_server__mysqld_options [[[
 #
 # Configuration options set in :file:`/etc/mysql/conf.d/mysqld.cnf` file. This is
@@ -255,6 +268,7 @@ mariadb_server__mysqld_options:
       - '{{ mariadb_server__mysqld_network_options }}'
       - '{{ mariadb_server__mysqld_pki_options }}'
       - '{{ mariadb_server__mysqld_cluster_options }}'
+      - '{{ mariadb_server__mysqld_directory_options }}'
       - '{{ mariadb_server__options }}'
 
                                                                    # ]]]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,6 +62,14 @@
     path: '/etc/mysql/mariadb.conf.d'
   register: mariadb_server__register_confd
 
+- name: Ensure MariaDB data directory exists
+  file:
+    path: '{{ mariadb_server__datadir }}'
+    state: 'directory'
+    owner: 'mysql'
+    group: 'mysql'
+    mode: '0755'
+
 - name: Configure database client on first install
   template:
     src: 'etc/mysql/conf.d/client.cnf.j2'


### PR DESCRIPTION
The play fails when user specify `datadir` directory that is not exist yet in `mariadb_server__options`.
(so user need to create directory manually with corresponding owner/group after fail)

Changes made in this pull requests will support:
* User can datadir specify by overriding variable
 `mariadb_server__datadir` in inventory
  (`/var/lib/mysql` by default)
* The directory will be created in task if not exist
* This directory will be set as 'datadir' option in server configuration file

Signed-off-by: tharada <harada.tomoyuki03@gmail.com>